### PR TITLE
Make Button Title Dependent on the Medication Modification State

### DIFF
--- a/Sources/SpeziMedication/MedicationSettings.swift
+++ b/Sources/SpeziMedication/MedicationSettings.swift
@@ -31,6 +31,14 @@ public struct MedicationSettings<MI: MedicationInstance>: View {
         medicationOptions(medicationSettingsViewModel)
     }
     
+    private var cancelButtonTitie: String {
+        if modifiedMedications {
+            String(localized: "Cancel", bundle: .module)
+        } else {
+            String(localized: "Close", bundle: .module)
+        }
+    }
+    
     public var body: some View {
         VStack(spacing: 0) {
             if viewModel.medicationInstances.isEmpty {
@@ -60,7 +68,7 @@ public struct MedicationSettings<MI: MedicationInstance>: View {
                 }
                 if let isPresented {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button(String(localized: "Cancel", bundle: .module)) {
+                        Button(cancelButtonTitie) {
                             if !modifiedMedications {
                                 isPresented.wrappedValue = false
                             } else {

--- a/Sources/SpeziMedication/Resources/Localizable.xcstrings
+++ b/Sources/SpeziMedication/Resources/Localizable.xcstrings
@@ -20,13 +20,30 @@
 
     },
     "Cancel" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
     },
     "Choose Days" : {
 
     },
     "Choose Interval" : {
 
+    },
+    "Close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        }
+      }
     },
     "Continue with no Medications" : {
 


### PR DESCRIPTION
# Make Button Title Dependent on the Medication Modification State

## :recycle: Current situation & Problem
- Feedback we received from users of the Medication Module:
> Upon clicking medication settings, the only way a user can go back is either by clicking "cancel" or swiping down from the upper third of the screen. Propose changing "cancel" to "close." Important to leave "cancel" when adding a new medication as in that situation you would be cancelling the action.


## :gear: Release Notes 
- Show "close" instead of "cancel" in the case that a medication has not yet been changed.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
