### PR TITLE
Lift to Spezi 1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,17 +21,13 @@ let package = Package(
         .library(name: "SpeziMedication", targets: ["SpeziMedication"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.1.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.2.0")
     ],
     targets: [
         .target(
             name: "SpeziMedication",
             dependencies: [
-                .product(name: "Spezi", package: "Spezi"),
-                .product(name: "SpeziViews", package: "SpeziViews"),
-                .product(name: "SpeziLocalStorage", package: "SpeziStorage")
+                .product(name: "SpeziViews", package: "SpeziViews")
             ],
             resources: [
                 .process("Resources")

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
         .library(name: "SpeziMedication", targets: ["SpeziMedication"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.8.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.6.2"))
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.1.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.2.0")
     ],
     targets: [
         .target(

--- a/Sources/SpeziMedication/MedicationSettings.swift
+++ b/Sources/SpeziMedication/MedicationSettings.swift
@@ -10,7 +10,7 @@ import SpeziViews
 import SwiftUI
 
 
-/// Present medication settings includings mechanisms to add, edit, and delete medications.
+/// Present medication settings including mechanisms to add, edit, and delete medications.
 public struct MedicationSettings<MI: MedicationInstance>: View {
     private let isPresented: Binding<Bool>?
     private let allowEmtpySave: Bool

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2FADBE9C2AF8761B0003EC4E /* XCUIApplication+ButtonTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FADBE9B2AF8761B0003EC4E /* XCUIApplication+ButtonTap.swift */; };
 		2FE5BC612AF86C5E0089B6C0 /* ExampleMedicationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5BC602AF86C5E0089B6C0 /* ExampleMedicationSettingsViewModel.swift */; };
 		2FE5BC632AF86CA20089B6C0 /* ExampleMedicationInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5BC622AF86CA20089B6C0 /* ExampleMedicationInstance.swift */; };
+		97B786BA2B717396004066DB /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 97B786B92B717396004066DB /* Spezi */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				97B786BA2B717396004066DB /* Spezi in Frameworks */,
 				2F68C3C8292EA52000B3E12C /* SpeziMedication in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -148,6 +150,7 @@
 			name = TestApp;
 			packageProductDependencies = (
 				2F68C3C7292EA52000B3E12C /* SpeziMedication */,
+				97B786B92B717396004066DB /* Spezi */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -199,6 +202,9 @@
 				Base,
 			);
 			mainGroup = 2F6D138928F5F384007C25D6;
+			packageReferences = (
+				97B786B82B717396004066DB /* XCRemoteSwiftPackageReference "Spezi" */,
+			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -683,10 +689,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		97B786B82B717396004066DB /* XCRemoteSwiftPackageReference "Spezi" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		2F68C3C7292EA52000B3E12C /* SpeziMedication */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziMedication;
+		};
+		97B786B92B717396004066DB /* Spezi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 97B786B82B717396004066DB /* XCRemoteSwiftPackageReference "Spezi" */;
+			productName = Spezi;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
# Lift to Spezi 1.0

## :recycle: Current situation & Problem
Currently, the Medication package depends on outdated packages like Spezi 0.8 and SpeziViews 0.6


## :gear: Release Notes 
- Lift dependencies to Spezi 1.0


## :books: Documentation
--


## :white_check_mark: Testing
Checked functionality via UI tests and unit tests


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
