### PR TITLE
Small Spelling Fix 

### DIFF
--- a/Sources/SpeziMedication/MedicationSettings.swift
+++ b/Sources/SpeziMedication/MedicationSettings.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// Present medication settings including mechanisms to add, edit, and delete medications.
 public struct MedicationSettings<MI: MedicationInstance>: View {
     private let isPresented: Binding<Bool>?
-    private let allowEmtpySave: Bool
+    private let allowEmptySave: Bool
     private let medicationSettingsViewModel: any MedicationSettingsViewModel<MI>
     private let action: () -> Void
         
@@ -101,7 +101,7 @@ public struct MedicationSettings<MI: MedicationInstance>: View {
     
     @MainActor private var saveMedicationButton: some View {
         let title: String
-        if viewModel.medicationInstances.isEmpty, !modifiedMedications && allowEmtpySave {
+        if viewModel.medicationInstances.isEmpty, !modifiedMedications && allowEmptySave {
             title = String(localized: "Continue with no Medications", bundle: .module)
         } else {
             title = String(localized: "Save Medications", bundle: .module)
@@ -128,7 +128,7 @@ isPresented?.wrappedValue = false
             }
         )
             .buttonStyle(.borderedProminent)
-            .disabled(!modifiedMedications && !allowEmtpySave)
+            .disabled(!modifiedMedications && !allowEmptySave)
             .padding()
             .background {
                 Color(uiColor: .systemGroupedBackground)
@@ -153,18 +153,18 @@ isPresented?.wrappedValue = false
     /// Initializes a new ``MedicationSettings`` view.
     /// - Parameters:
     ///   - isPresented: An optional binding to allow the ``MedicationSettings`` view to control the presentation of itself, should be used in combination with e.g. a `.sheet(isPresented:)` modifier.
-    ///   - allowEmtpySave: Flag to determine if saving without any medication instances is allowed.
+    ///   - allowEmptySave: Flag to determine if saving without any medication instances is allowed.
     ///   - medicationSettingsViewModel: The ``MedicationSettingsViewModel`` to manage the medication settings.
     ///   - action: An optional closure to be executed after persisting medications and performing custom logic.
     public init( // swiftlint:disable:this function_default_parameter_at_end
         // We disable the default parameter order here to ensure that the action can be a trailing closure but only needs to be optionally provided.
         isPresented: Binding<Bool>? = nil,
-        allowEmtpySave: Bool = false,
+        allowEmptySave: Bool = false,
         medicationSettingsViewModel: any MedicationSettingsViewModel<MI>,
         action: @escaping () -> Void = {}
     ) {
         self.isPresented = isPresented
-        self.allowEmtpySave = allowEmtpySave
+        self.allowEmptySave = allowEmptySave
         self.medicationSettingsViewModel = medicationSettingsViewModel
         self.action = action
         self.viewModel = medicationSettingsViewModel.internalViewModel


### PR DESCRIPTION
# Small Spelling Fix

## :recycle: Current situation & Problem
I noticed when using MedicationSettings that "allowEmptySave" was spelled "allowEmtpySave".


## :gear: Release Notes 



## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
