### PR TITLE
Fixing decoding times if times was never encoded error

### DIFF
--- a/Sources/SpeziMedication/Models/Schedule.swift
+++ b/Sources/SpeziMedication/Models/Schedule.swift
@@ -38,7 +38,7 @@ public struct Schedule: Codable, Equatable, Hashable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.frequency = try container.decode(Frequency.self, forKey: .frequency)
-        self.times = try container.decode([ScheduledTime].self, forKey: .times)
+        self.times = try container.decodeIfPresent([ScheduledTime].self, forKey: .times) ?? []
         self.startDate = try container.decode(Date.self, forKey: .startDate)
     }
     

--- a/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
+++ b/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
@@ -12,6 +12,51 @@ import XCTest
 
 final class SpeziMedicationTests: XCTestCase {
     // swiftlint:disable:next function_body_length
+    
+    func testScheduleDecodingWithAndWithoutTimes() throws {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .iso8601
+
+        // Test decoding without times
+        let noTimesJSON = """
+        {
+            "frequency": {
+                "asNeeded": true
+            },
+            "startDate": "2023-12-07T08:00:00Z"
+        }
+        """.data(using: .utf8)!
+        let noTimesSchedule = try jsonDecoder.decode(Schedule.self, from: noTimesJSON)
+        XCTAssertEqual(noTimesSchedule.times, nil)
+
+        // Test decoding with times
+        let withTimesJSON = """
+        {
+            "frequency": {
+                "regularDayIntervals": 2
+            },
+            "startDate": "2023-12-07T08:00:00Z",
+            "times": [
+                {
+                    "time": {
+                        "hour": 8,
+                        "minute": 0
+                    }
+                },
+                {
+                    "time": {
+                        "hour": 15,
+                        "minute": 0
+                    }
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+        let withTimesSchedule = try jsonDecoder.decode(Schedule.self, from: withTimesJSON)
+        XCTAssertNotNil(withTimesSchedule.times)
+    }
+    
+    
     func testScheduleEncoding() throws {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
+++ b/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
@@ -27,7 +27,7 @@ final class SpeziMedicationTests: XCTestCase {
         }
         """.data(using: .utf8)!
         let noTimesSchedule = try jsonDecoder.decode(Schedule.self, from: noTimesJSON)
-        XCTAssertEqual(noTimesSchedule.times, nil)
+        XCTAssertEqual(noTimesSchedule.times, [])
 
         // Test decoding with times
         let withTimesJSON = """
@@ -41,13 +41,15 @@ final class SpeziMedicationTests: XCTestCase {
                     "time": {
                         "hour": 8,
                         "minute": 0
-                    }
+                    },
+                    "dosage": 5.0
                 },
                 {
                     "time": {
                         "hour": 15,
                         "minute": 0
-                    }
+                    },
+                    "dosage": 5.0
                 }
             ]
         }

--- a/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
+++ b/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
@@ -11,7 +11,6 @@ import XCTest
 
 
 final class SpeziMedicationTests: XCTestCase {
-    
     func testScheduleDecodingWithAndWithoutTimes() throws {
         let jsonDecoder = JSONDecoder()
         jsonDecoder.dateDecodingStrategy = .iso8601
@@ -24,8 +23,12 @@ final class SpeziMedicationTests: XCTestCase {
             },
             "startDate": "2023-12-07T08:00:00Z"
         }
-        """.data(using: .utf8)!
-        let noTimesSchedule = try jsonDecoder.decode(Schedule.self, from: noTimesJSON)
+        """
+        guard let data = noTimesJSON.data(using: .utf8) else {
+            XCTFail("Failed to encode JSON string to Data")
+            return
+        }
+        let noTimesSchedule = try jsonDecoder.decode(Schedule.self, from: data)
         XCTAssertEqual(noTimesSchedule.times, [])
 
         // Test decoding with times
@@ -52,8 +55,12 @@ final class SpeziMedicationTests: XCTestCase {
                 }
             ]
         }
-        """.data(using: .utf8)!
-        let withTimesSchedule = try jsonDecoder.decode(Schedule.self, from: withTimesJSON)
+        """
+        guard let dataWithTimes = withTimesJSON.data(using: .utf8) else {
+            XCTFail("Failed to encode JSON string to Data")
+            return
+        }
+        let withTimesSchedule = try jsonDecoder.decode(Schedule.self, from: dataWithTimes)
         XCTAssertNotNil(withTimesSchedule.times)
     }
     

--- a/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
+++ b/Tests/SpeziMedicationTests/SpeziMedicationTests.swift
@@ -11,7 +11,6 @@ import XCTest
 
 
 final class SpeziMedicationTests: XCTestCase {
-    // swiftlint:disable:next function_body_length
     
     func testScheduleDecodingWithAndWithoutTimes() throws {
         let jsonDecoder = JSONDecoder()
@@ -58,7 +57,7 @@ final class SpeziMedicationTests: XCTestCase {
         XCTAssertNotNil(withTimesSchedule.times)
     }
     
-    
+    // swiftlint:disable:next function_body_length
     func testScheduleEncoding() throws {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]


### PR DESCRIPTION
# [*Fixing Decoding Times Error*](https://github.com/StanfordSpezi/SpeziMedication/pull/12#issue-2182904376)

## :gear: Release Notes 
- This PR changes the decoding schedule, so it only decodes the times field if it is present. This is necessary because times is not encoded if it was empty, so then it errors when trying to decode it if it was never encoded.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
